### PR TITLE
UPSTREAM: <carry>: enable TCP_USER_TIMEOUT on client connections

### DIFF
--- a/transport/cache.go
+++ b/transport/cache.go
@@ -18,11 +18,12 @@ package transport
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	libgonetwork "github.com/openshift/library-go/pkg/network"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -90,10 +91,7 @@ func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
 
 	dial := config.Dial
 	if dial == nil {
-		dial = (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext
+		dial = libgonetwork.DefaultClientDialContext()
 	}
 
 	// If we use are reloading files, we need to handle certificate rotation properly


### PR DESCRIPTION
it allows the client to detect broken connections to the api server more quickly than the default TCP timeout of 15 minutes.
