### PR TITLE
Bug 1989505: UPSTREAM 104172: revert "fix wrong output when using jsonpath"

### DIFF
--- a/util/jsonpath/jsonpath.go
+++ b/util/jsonpath/jsonpath.go
@@ -132,9 +132,6 @@ func (j *JSONPath) FindResults(data interface{}) ([][]reflect.Value, error) {
 			}
 			continue
 		}
-		if len(results) == 0 {
-			break
-		}
 		fullResult = append(fullResult, results)
 	}
 	return fullResult, nil

--- a/util/jsonpath/jsonpath_test.go
+++ b/util/jsonpath/jsonpath_test.go
@@ -280,6 +280,7 @@ func TestStructInput(t *testing.T) {
 
 	missingKeyTests := []jsonpathTest{
 		{"nonexistent field", "{.hello}", storeData, "", false},
+		{"nonexistent field 2", "before-{.hello}after", storeData, "before-after", false},
 	}
 	testJSONPath(missingKeyTests, true, t)
 

--- a/util/jsonpath/jsonpath_test.go
+++ b/util/jsonpath/jsonpath_test.go
@@ -806,8 +806,8 @@ func TestRunningPodsJSONPathOutput(t *testing.T) {
 	testJSONPath(
 		[]jsonpathTest{
 			{
-				"when range is used in a certain way in script, additional line is printed",
-				`{range .items[?(.status.phase=="Running")]}{.metadata.name}{" is Running\n"}`,
+				"range over pods without selecting the last one",
+				`{range .items[?(.status.phase=="Running")]}{.metadata.name}{" is Running\n"}{end}`,
 				data,
 				"pod1 is Running\npod2 is Running\npod3 is Running\n",
 				false, // expect no error


### PR DESCRIPTION
This partially reverts commit kubernetes/kubernetes#98057

the original problem was caused by not using {end} at the end of the range. Please see attached jsonpath documentation on using range.

The reverted commit causes a new bug of not parsing missing keys incorrectly (added a unit test for this use case)

/assign @soltysh 
cc @sttts 